### PR TITLE
Clonefield function

### DIFF
--- a/scripts/addField.js
+++ b/scripts/addField.js
@@ -1,0 +1,17 @@
+// Find button
+// on click execute action. 1-Event 2-Element
+document.querySelector("#add-time").addEventListener('click', cloneField)
+
+function cloneField() {
+    // duplicate fields
+   const newField = document.querySelector('.schedule-item').cloneNode(true)
+    //    clean fields before displaying them. 1- Find the fields we will clean
+    const fields = newField.querySelectorAll('input')
+    // clean each one of the fields
+    fields.forEach(function(field) {
+        fields.value = ""
+    })
+    
+    // display
+    document.querySelector('#schedule-items').appendChild(newField)
+}

--- a/teach.html
+++ b/teach.html
@@ -7,6 +7,7 @@
         <link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700&display=swap" rel="stylesheet">
         <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,400;0,600;0,700;1,400&display=swap" rel="stylesheet">
         <link rel="stylesheet" href="/assets/styles/index.css">
+        <script src="/scripts/addField.js" defer></script>
     </head>
     <body id="page-teach">
         <div id="container">
@@ -76,7 +77,7 @@
 
                         <fieldset id="schedule-items">
                             <legend>Horários disponíveis
-                                <button id="add-time">+ Novo Horário</button>
+                                <button type="button" id="add-time">+ Novo Horário</button>
                             </legend>
 
                             <div class="schedule-item">


### PR DESCRIPTION
cloneNode - O método Node.cloneNode() duplica um elemento node (nó) da estrutura de um documento DOM. Ele retorna um clone do elemento para o qual foi invocado.
SYNTAX: var dupNode = node.cloneNode(deep);

node -> O elemento node (nó) a ser clonado 'duplicado'.
dupNode -> O novo elemento node (nó) resultado da clonagem do elemento node.
deep Optional [1] -> true se os elementos filhos do nó que está sendo clonado devem ser clonados juntos, ou false para clonar apenas o nó específico dispensando, assim, qualquer elemento DOM filho. 
* https://developer.mozilla.org/pt-BR/docs/Web/API/Node/cloneNode
appendChild -https://developer.mozilla.org/pt-BR/docs/Web/API/Node/appendChild